### PR TITLE
Mod External reference resolver should not overwrite reference links on save

### DIFF
--- a/src/main/java/org/folio/rest/advice/ReferenceLinkControllerAdvice.java
+++ b/src/main/java/org/folio/rest/advice/ReferenceLinkControllerAdvice.java
@@ -1,0 +1,20 @@
+package org.folio.rest.advice;
+
+import org.folio.rest.exception.ReferenceLinkExistsException;
+import org.folio.rest.model.ReferenceLink;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@ControllerAdvice
+public class ReferenceLinkControllerAdvice {
+
+  @ExceptionHandler(value = ReferenceLinkExistsException.class)
+  public @ResponseBody ResponseEntity<ReferenceLink> handleInvalidValuePathException(ReferenceLinkExistsException exception) {
+    return ResponseEntity.accepted().body(exception.getReferenceLink());
+  }
+
+}

--- a/src/main/java/org/folio/rest/config/RepositoryRestConfig.java
+++ b/src/main/java/org/folio/rest/config/RepositoryRestConfig.java
@@ -1,0 +1,14 @@
+package org.folio.rest.config;
+
+import org.folio.rest.handler.ReferenceLinkEventHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RepositoryRestConfig {
+
+  @Bean
+  ReferenceLinkEventHandler referenceLinkEventHandler() {
+    return new ReferenceLinkEventHandler();
+  }
+}

--- a/src/main/java/org/folio/rest/exception/ReferenceLinkExistsException.java
+++ b/src/main/java/org/folio/rest/exception/ReferenceLinkExistsException.java
@@ -1,0 +1,20 @@
+package org.folio.rest.exception;
+
+import org.folio.rest.model.ReferenceLink;
+
+public class ReferenceLinkExistsException extends RuntimeException {
+
+  private static final long serialVersionUID = 8239125524416844006L;
+
+  private final ReferenceLink referenceLink;
+
+  public ReferenceLinkExistsException(ReferenceLink referenceLink) {
+    super("Reference Link Already Exists");
+    this.referenceLink = referenceLink;
+  }
+
+  public ReferenceLink getReferenceLink() {
+    return referenceLink;
+  }
+
+}

--- a/src/main/java/org/folio/rest/handler/ReferenceLinkEventHandler.java
+++ b/src/main/java/org/folio/rest/handler/ReferenceLinkEventHandler.java
@@ -1,0 +1,26 @@
+package org.folio.rest.handler;
+
+import java.util.Optional;
+
+import org.folio.rest.exception.ReferenceLinkExistsException;
+import org.folio.rest.model.ReferenceLink;
+import org.folio.rest.model.repo.ReferenceLinkRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.core.annotation.HandleBeforeCreate;
+import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+
+@RepositoryEventHandler(ReferenceLink.class)
+public class ReferenceLinkEventHandler {
+
+  @Autowired
+  private ReferenceLinkRepo referenceLinkRepo;
+
+  @HandleBeforeCreate
+  public void handleReferenceLinkBeforeCreate(ReferenceLink referenceLink){
+    Optional<ReferenceLink> existingReferenceLink = referenceLinkRepo.findByTypeIdAndExternalReference(referenceLink.getType().getId(), referenceLink.getExternalReference());
+
+    if (existingReferenceLink.isPresent()) {
+      throw new ReferenceLinkExistsException(existingReferenceLink.get());
+    }
+  }
+}

--- a/src/main/java/org/folio/rest/model/ReferenceLink.java
+++ b/src/main/java/org/folio/rest/model/ReferenceLink.java
@@ -2,12 +2,18 @@ package org.folio.rest.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 
 import org.folio.rest.domain.model.AbstractBaseEntity;
 
 @Entity
+@Table(uniqueConstraints = {
+  @UniqueConstraint(columnNames = { "externalReference", "type_id" })
+})
 public class ReferenceLink extends AbstractBaseEntity {
 
   @NotNull
@@ -20,6 +26,7 @@ public class ReferenceLink extends AbstractBaseEntity {
 
   @NotNull
   @ManyToOne
+  @JoinColumn(name="type_id")
   private ReferenceLinkType type;
 
   public ReferenceLink() {

--- a/src/main/java/org/folio/rest/model/repo/ReferenceLinkRepo.java
+++ b/src/main/java/org/folio/rest/model/repo/ReferenceLinkRepo.java
@@ -1,6 +1,7 @@
 package org.folio.rest.model.repo;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.folio.rest.model.ReferenceLink;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,6 +23,9 @@ public interface ReferenceLinkRepo extends JpaRepository<ReferenceLink, String>,
       @Param("externalReference") String externalReference);
 
   public List<ReferenceLink> findAllByFolioReference(@Param("folioReference") String folioReference);
+
+  public Optional<ReferenceLink> findByTypeIdAndExternalReference(@Param("typeId") String typeId,
+    @Param("externalReference") String externalReference);
 
   @Transactional
   public long deleteByTypeName(@Param("typeName") String typeName);


### PR DESCRIPTION
Mod External reference resolver should not overwrite reference links on save

Follow a "fail-through" strategy while ensuring that saving does not overwrite any existing reference link.

Utilize a before create event handler to override the create method.
This new create will prevent the save if the reference link already exists.
The existing reference link will be returned, mocking the save process, so that the caller need not care whether or not the reference link already existed before saving.

This adds the SQL constraint to ensure that inconsistent states are impossible.
Particularly because the added repo method `findByTypeIdAndExternalReference()` assumes that this find operation will only have one entity to return.

Alternative methods, such as those described in the link below, were not functioning as expected and could not be used:
- https://docs.spring.io/spring-data/rest/docs/current/reference/html/#customizing-sdr.overriding-sdr-response-handlers

resolves #16 